### PR TITLE
feat: add route-redirect example

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -5,6 +5,7 @@
     "name": "Benutzername",
     "page": "Profilseite",
     "login": "Anmeldung",
+    "logout": "Abmelden",
     "welcome": "Wilkommen {user}!"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,7 @@
     "name": "User name",
     "page": "Profile",
     "login": "Login",
+    "logout": "Logout",
     "welcome": "Welcome {user}!"
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,6 +42,7 @@ export default defineNuxtConfig({
     },
   ],
   i18n: {
+    strategy: "no_prefix",
     locales: getLocales(),
     defaultLocale: "en",
     langDir: "locales",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,6 +24,15 @@ export default defineNuxtConfig({
     },
   },
   css: ["vuetify/styles"],
+  hooks: {
+    "pages:extend"(pages) {
+      pages.push({
+        name: "user",
+        path: "/user",
+        redirect: "/login",
+      });
+    },
+  },
   modules: [
     "@nuxtjs/i18n",
     (_options, nuxt) => {

--- a/pages/user/[userId].vue
+++ b/pages/user/[userId].vue
@@ -11,6 +11,11 @@
       <v-card-text>
         <p>{{ i18n.t("user.welcome", { user: $route.params.userId }) }}</p>
       </v-card-text>
+      <v-card-actions>
+        <v-btn @click="logout">
+          {{ i18n.t("user.logout") }}
+        </v-btn>
+      </v-card-actions>
     </v-card>
   </v-app>
 </template>
@@ -19,8 +24,15 @@
 import { mdiAccountCircle } from "@mdi/js";
 
 const i18n = useI18n();
+const localePath = useLocalePath();
+
+const router = useRouter();
 
 useHead({
   title: i18n.t("user.page") + " " + useRoute().params.userId,
 });
+
+function logout() {
+  router.push(localePath({ name: "user" }));
+}
 </script>


### PR DESCRIPTION
Add an example for a route-redirect.

This uses the `pages:extend` hook: https://nuxt.com/docs/guide/going-further/custom-routing#using-the-pagesextend-hook