### PR TITLE
build: simplify font copy logic

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,19 +39,8 @@ export default defineNuxtConfig({
   css: ["vuetify/styles"],
   modules: ["@nuxtjs/i18n", "@nuxtjs/robots"],
   hooks: {
-    "nitro:build:before": (nitro) => {
-      if (!nitro.options.dev) return;
-
+    "nitro:build:before": () => {
       const fontsDir = "public/assets/fonts/";
-
-      fs.cpSync("node_modules/@fontsource/", fontsDir, {
-        recursive: true,
-      });
-      console.log(chalk.green("√"), "Copied fonts to " + fontsDir);
-    },
-    "nitro:build:public-assets": (nitro) => {
-      const publicDir = nitro.options.output.publicDir;
-      const fontsDir = publicDir + "/assets/fonts/";
 
       fs.cpSync("node_modules/@fontsource/", fontsDir, {
         recursive: true,


### PR DESCRIPTION
Simplify the font copy logic by using one hook only, which is possible as the public dir is kept as of 758c74a16d38aa4b98f722ddeb2c2a99cebf4ed4.