### PR TITLE
test: add `side-by-side` theme for chromatic

### DIFF
--- a/.storybook/StoryWrapper.vue
+++ b/.storybook/StoryWrapper.vue
@@ -1,9 +1,16 @@
 <template>
-  <v-app :theme="themeName">
-    <v-main>
-      <slot name="story"></slot>
-    </v-main>
-  </v-app>
+  <div style="display: flex">
+    <v-app :theme="themeName === 'side-by-side' ? 'light' : themeName">
+      <v-main>
+        <slot name="story"></slot>
+      </v-main>
+    </v-app>
+    <v-app v-if="themeName === 'side-by-side'" theme="dark">
+      <v-main>
+        <slot name="story"></slot>
+      </v-main>
+    </v-app>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -19,6 +19,7 @@ export const globalTypes = {
       items: [
         { value: "light", title: "Light", icon: "circlehollow" },
         { value: "dark", title: "Dark", icon: "circle" },
+        { value: "side-by-side", title: "Side by Side", icon: "sidebar" },
       ],
       // Change title based on selected value
       dynamicTitle: true,

--- a/.storybook/withVuetifyTheme.decorator.ts
+++ b/.storybook/withVuetifyTheme.decorator.ts
@@ -1,4 +1,5 @@
 import { h } from "vue";
+import isChromatic from "chromatic";
 import StoryWrapper from "./StoryWrapper.vue";
 
 export const DEFAULT_THEME = "light";
@@ -7,7 +8,9 @@ export const withVuetifyTheme = (
   storyFn: () => any,
   context: { globals: { theme: string }; args: {} },
 ) => {
-  const globalTheme = context.globals.theme || DEFAULT_THEME;
+  const globalTheme = isChromatic()
+    ? "side-by-side"
+    : context.globals.theme || DEFAULT_THEME;
   const story = storyFn();
 
   return () => {


### PR DESCRIPTION
Add `side-by-side` theme to test light and dark mode next to each other in chromatic.