### PR TITLE
fix: add `eslint`, `vue` and `vite` as (dev-)dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
     "chromatic": "npx chromatic"
   },
   "dependencies": {
-    "@jojomatik/nuxt-bundle": "^1.0.0-beta.12",
-    "nuxt": "^3.9.1"
+    "@jojomatik/nuxt-bundle": "jojomatik/nuxt-bundle#fix/peer-deps",
+    "nuxt": "^3.9.1",
+    "vue": "^3.4.8"
   },
   "devDependencies": {
+    "eslint": "^8.56.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "prettier": "^3.0.3"
+    "prettier": "^3.0.3",
+    "vite": "^5.0.11"
   },
   "version": "1.0.0-beta.86"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,10 +1573,9 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@jojomatik/nuxt-bundle@^1.0.0-beta.12":
+"@jojomatik/nuxt-bundle@jojomatik/nuxt-bundle#fix/peer-deps":
   version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@jojomatik/nuxt-bundle/-/nuxt-bundle-1.0.0-beta.12.tgz#dd9699794a2b43a7edf499c1bfe97cd1dec6f1af"
-  integrity sha512-QCK14h0QgCfhsxoe9vmzggsvgMPKAX7nizRyrL7BtA9WP/LiidaxS5dhxAhJF7V9o35Kgm8PN4lDl0x9fXHObQ==
+  resolved "https://codeload.github.com/jojomatik/nuxt-bundle/tar.gz/4c9426fc1b8572b711c57a16ca248b78d2892cab"
   dependencies:
     "@fontsource/roboto" "5.0.8"
     "@intlify/core-base" "9.9.0"
@@ -1599,7 +1598,6 @@
     "@unhead/vue" "1.8.9"
     chromatic "10.2.0"
     conventional-changelog-conventionalcommits "7.0.2"
-    eslint "8.56.0"
     eslint-config-prettier "9.1.0"
     eslint-plugin-prettier "5.1.3"
     eslint-plugin-storybook "0.6.15"
@@ -1615,9 +1613,7 @@
     typescript "5.3.3"
     unplugin-auto-import "0.17.3"
     unplugin-vue-components "0.26.0"
-    vite "5.0.11"
     vite-plugin-vuetify "2.0.1"
-    vue "3.4.8"
     vue-i18n "9.9.0"
     vue-router "4.2.5"
     vuetify "3.4.10"
@@ -6519,7 +6515,7 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@8.56.0:
+eslint@^8.56.0:
   version "8.56.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.56.0.tgz#4957ce8da409dc0809f99ab07a1b94832ab74b15"
   integrity sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==
@@ -12837,7 +12833,7 @@ vite-plugin-vuetify@2.0.1:
     debug "^4.3.3"
     upath "^2.0.1"
 
-vite@5.0.11, vite@^5.0.0:
+vite@5.0.11, vite@^5.0.0, vite@^5.0.11:
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.11.tgz#31562e41e004cb68e1d51f5d2c641ab313b289e4"
   integrity sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==
@@ -12981,7 +12977,7 @@ vue-router@4.2.5, vue-router@^4.2.5:
   dependencies:
     "@vue/devtools-api" "^6.5.0"
 
-vue@3.4.8, vue@^3.4.5:
+vue@^3.4.5, vue@^3.4.8:
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.4.8.tgz#a7a5b4692fe19deb211fdfe30509d9b68c8d909b"
   integrity sha512-vJffFOe6DqWsAI10v3tDhb1nJrj7CF3CbdQwOznywAsFNoyvrQ1AWQdcIWJpmRpRnw7NFzstzh6fh4w7n1PNdg==


### PR DESCRIPTION
Add `eslint`, `vue` and `vite` as (dev-)dependencies as they have been made peer-dependencies only of `nuxt-bundle`.